### PR TITLE
Fix escaping of backslashes in file paths see #1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Chez Scheme REPL for Visual Studio Code Changelog
 
+## Version 0.2.0 (2023-06-26)
+
+### Bugfixes
+
+- Fix [#1](https://github.com/Release-Candidate/vscode-scheme-repl/issues/1). Evaluating does not work on Windows, because backslashes in Windows file paths are not escaped. Leads to Chez error messages like `Exception in read: invalid string character \U` for a file path `C:\User\...`.
+
 ## Version 0.1.0 (2023-06-23)
 
 Initial release

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "vscode-scheme-repl",
     "displayName": "Chez Scheme REPL",
-    "version": "0.1.0",
+    "version": "0.2.0",
     "preview": false,
     "publisher": "release-candidate",
     "description": "Support for Chez Scheme.",

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -65,6 +65,8 @@ export function setREPLPrompt(prompt: string): string {
 /**
  * Return the command to send to a running Chez REPL to load the file
  * `fileName` and evaluate `sexp`.
+ * Escapes backslashes in the file path (Windows paths) to be able to load files
+ * on windows.
  * The lambda to `load` helps in getting a bit of context about an error, if an
  * error occurs when loading `fileName`.
  * Set the REPL prompt to `replPrompt`.
@@ -74,7 +76,8 @@ export function setREPLPrompt(prompt: string): string {
  * `fileName` and evaluate `sexp`.
  */
 export function replLoadFileAndSexp(fileName: string, sexp: string): string {
-    return `(load "${fileName}" (lambda (x) (pretty-print (if (annotation? x) (annotation-stripped x) x)) (newline) (eval x)))\n${setREPLPrompt(
+    const sanitized = fileName.replace(/\\/gu, "\\\\");
+    return `(load "${sanitized}" (lambda (x) (pretty-print (if (annotation? x) (annotation-stripped x) x)) (newline) (eval x)))\n${setREPLPrompt(
         replPrompt
     )}\n ${sexp}`;
 }

--- a/src/paneREPL.ts
+++ b/src/paneREPL.ts
@@ -124,7 +124,7 @@ export async function expandLastInRepl(
 }
 
 /**
- * Send the result of applying `f` to the current selection to the pane REPL.
+ * Send the result of applying `data.f` to the current selection to the pane REPL.
  * @param data The needed data.
  */
 async function doSelectionInRepl(data: {
@@ -155,7 +155,7 @@ async function doSelectionInRepl(data: {
 }
 
 /**
- * Send the result of applying `f` to the sexp to the left of the cursor to the
+ * Send the result of applying `data.f` to the sexp to the left of the cursor to the
  * pane REPL.
  * @param data The needed data.
  */


### PR DESCRIPTION
Evaluating does not work on Windows, because backslashes in Windows file paths are not escaped. The `(load "PATH")` fails with an error like `Exception in read: invalid string character \U` for a file path `C:\User\...`.
