### PR TITLE
Fix windows line endings in sexp parsing, see #3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Chez Scheme REPL for Visual Studio Code Changelog
 
+## Version 0.3.0 (2023-06-26)
+
+### Bugfixes
+
+- Fix [#3](https://github.com/Release-Candidate/vscode-scheme-repl/issues/3). Windows line endings - `\r\n` instead of `\n` break parsing of sexps for **evalLastSexp**, only the last line of a sexp is evaluated if the sexp spans multiple lines.
+
 ## Version 0.2.0 (2023-06-26)
 
 ### Bugfixes

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "vscode-scheme-repl",
     "displayName": "Chez Scheme REPL",
-    "version": "0.2.0",
+    "version": "0.3.0",
     "preview": false,
     "publisher": "release-candidate",
     "description": "Support for Chez Scheme.",

--- a/src/evalREPL.ts
+++ b/src/evalREPL.ts
@@ -46,7 +46,8 @@ const notAnEnvRegex =
  * function of the REPL.
  * The last expression is saved in the match group `last`.
  */
-const lastExprRegex = /\n(?<last>[^\n]+)\s+(\S?\S?\S?[>%@#$~^&])\s\2?\s?\n*$/su;
+const lastExprRegex =
+    /\r?\n(?<last>[^\n]+)\s+(\S?\S?\S?[>%@#$~^&])\s\2?\s?\r?\n*$/su;
 
 /**
  * Returns a list of identifiers beginning with the string `prefix` or
@@ -346,7 +347,7 @@ async function evalSexp(
  */
 function matchREPLResponse(group: string): RegExp {
     return new RegExp(
-        `(?:${c.replPrompt}\\s+)+${group}\\n${c.replPrompt}\\s+$`,
+        `(?:${c.replPrompt}\\s+)+${group}\\r?\\n${c.replPrompt}\\s+$`,
         "su"
     );
 }

--- a/src/sexps.ts
+++ b/src/sexps.ts
@@ -156,6 +156,7 @@ function startOfSexp(data: {
  * right end of the string, if present and the following string until the left
  * end of the current sexp.
  */
+// eslint-disable-next-line max-lines-per-function
 function listSeparators(data: {
     s: string;
     delim: Delimiter | undefined;
@@ -169,6 +170,7 @@ function listSeparators(data: {
             delimStack: data.delimStack,
             level: data.level,
             delimString: ",",
+            numChars: 1,
         });
     } else if (data.s.endsWith(" ")) {
         return addDelimAndContinue({
@@ -177,6 +179,16 @@ function listSeparators(data: {
             delimStack: data.delimStack,
             level: data.level,
             delimString: " ",
+            numChars: 1,
+        });
+    } else if (data.s.endsWith("\r\n")) {
+        return addDelimAndContinue({
+            s: data.s,
+            delim: data.delim,
+            delimStack: data.delimStack,
+            level: data.level,
+            delimString: "\r\n",
+            numChars: 2,
         });
     } else if (data.s.endsWith("\n")) {
         return addDelimAndContinue({
@@ -185,6 +197,7 @@ function listSeparators(data: {
             delimStack: data.delimStack,
             level: data.level,
             delimString: "\n",
+            numChars: 1,
         });
     } else if (data.s.endsWith("\t")) {
         return addDelimAndContinue({
@@ -193,6 +206,7 @@ function listSeparators(data: {
             delimStack: data.delimStack,
             level: data.level,
             delimString: "\t",
+            numChars: 1,
         });
     }
     return undefined;
@@ -413,10 +427,14 @@ function addDelimAndContinue(data: {
     delimStack: Delimiter[];
     level: number;
     delimString: string;
+    numChars: number;
 }): string {
     return (
-        parseSexpToLeft(data.delimStack, data.s.slice(0, -1), data.level) +
-        data.delimString
+        parseSexpToLeft(
+            data.delimStack,
+            data.s.slice(0, -data.numChars),
+            data.level
+        ) + data.delimString
     );
 }
 


### PR DESCRIPTION
Parsing of s-expressions does not work with Windows-style line endings, with `\r\n` instead of just `\n`.
Add the missing carriage returns `\r`.

See #3 