### PR TITLE
Make delay after starting the terminal configurable, add popup on configuration changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Chez Scheme REPL for Visual Studio Code Changelog
 
+## Version 0.4.0 (2023-06-26)
+
+- Make the delay between starting the terminal for the interactive REPL and sending data to this terminal configurable. Configuration value `chezScheme.replDelay`. See [#5](https://github.com/Release-Candidate/vscode-scheme-repl/issues/5).
+- If the extension's configuration has changed, pop up a window asking the user to reload the extension to activate the changes.
+
 ## Version 0.3.0 (2023-06-26)
 
 ### Bugfixes

--- a/README.md
+++ b/README.md
@@ -109,6 +109,7 @@ The following list of extensions is recognized as a Chez Scheme source file:
 ## Configuration
 
 - `chezScheme.schemePath` - Path to the Chez Scheme executable `scheme`. Can be either an absolute path or relative to the workspace root. Default: `scheme`, which works if `scheme` is in your `PATH`.
+- `chezScheme.replDelay` - The delay in milliseconds `ms` to wait after starting a terminal for the interactive REPL until sending sources to it. Default: 1000ms, 1s.
 - `chezScheme.waiterPrompt` - The string to display as an interactive REPL prompt. Default: `λ>`.
 
 ## VS Code Scheme specific configuration

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "vscode-scheme-repl",
     "displayName": "Chez Scheme REPL",
-    "version": "0.3.0",
+    "version": "0.4.0",
     "preview": false,
     "publisher": "release-candidate",
     "description": "Support for Chez Scheme: Highlighting, autocompletion, documentation on hover and syntax checks.",
@@ -221,6 +221,11 @@
                     "type": "string",
                     "default": "scheme",
                     "markdownDescription": "Path to the Chez Scheme executable `scheme`. Can be either an absolute path or relative to the workspace root. Default: `scheme`, which works if `scheme` is in your `PATH`."
+                },
+                "chezScheme.replDelay": {
+                    "type": "integer",
+                    "default": 1000,
+                    "markdownDescription": "The delay in milliseconds `ms` to wait after starting a terminal for the interactive REPL until sending sources to it. Default: 1000ms, 1s."
                 },
                 "chezScheme.waiterPrompt": {
                     "type": "string",

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -206,10 +206,32 @@ export const cfgREPLPath = "schemePath";
 export const cfgREPLDefaultPath = replCommand;
 
 /**
+ * The configuration key for the REPL start delay.
+ */
+export const cfgREPLDelay = "replDelay";
+
+/**
+ * The default value of `cfgREPLDelay`.
+ */
+export const cfgREPLDefaultDelay = replSleepTime;
+
+/**
+ * Return the configuration value for `replDelay`.
+ * @param config The configuration object to use.
+ * @returns The configuration value for `replDelay`.
+ */
+export function getCfgREPLDelay(config: vscode.WorkspaceConfiguration): number {
+    return config.get<number>(cfgREPLDelay) || cfgREPLDefaultDelay;
+}
+
+/**
  * The string to use as the Chez REPL prompt.
  */
 export const cfgREPLPrompt = "waiterPrompt";
 
+/**
+ * The default value of `cfgREPLPrompt`.
+ */
 export const cfgREPLDefaultPrompt = replPrompt;
 
 /**
@@ -217,7 +239,7 @@ export const cfgREPLDefaultPrompt = replPrompt;
  * @param config The configuration object to use.
  * @returns The configuration value for `schemePath`.
  */
-export function getCfgREPLPath(config: vscode.WorkspaceConfiguration) {
+export function getCfgREPLPath(config: vscode.WorkspaceConfiguration): string {
     return config.get<string>(cfgREPLPath) || cfgREPLDefaultPath;
 }
 
@@ -230,7 +252,7 @@ export function getCfgREPLPath(config: vscode.WorkspaceConfiguration) {
  */
 export function getCfgREPLPromptFunction(
     config: vscode.WorkspaceConfiguration
-) {
+): string {
     const promptString =
         config.get<string>(cfgREPLPrompt) || cfgREPLDefaultPrompt;
     return setREPLPrompt(promptString);

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -64,6 +64,7 @@ export async function activate(context: vscode.ExtensionContext) {
  * Setup the extension.
  * @param env The extension's environment.
  */
+// eslint-disable-next-line max-statements
 async function setupExtension(env: h.Env) {
     const editorChangedSubscription = vscode.window.onDidChangeActiveTextEditor(
         (editor) => {
@@ -73,6 +74,11 @@ async function setupExtension(env: h.Env) {
     env.context.subscriptions.push(editorChangedSubscription);
 
     subscribeOnSave(env);
+
+    const configSubscription = vscode.workspace.onDidChangeConfiguration((e) =>
+        configChanged(env, e)
+    );
+    env.context.subscriptions.push(configSubscription);
 
     const symbolSubscription = vscode.languages.registerDocumentSymbolProvider(
         c.languageName,
@@ -285,4 +291,24 @@ function registerTextEditorCommand(
         (editor) => f(env, editor)
     );
     env.context.subscriptions.push(subscription);
+}
+
+/**
+ * Called, if the configuration has changed.
+ * @param env The extension's environment.
+ * @param e The change event.
+ */
+function configChanged(env: h.Env, e: vscode.ConfigurationChangeEvent) {
+    if (e.affectsConfiguration(c.cfgSection)) {
+        env.outChannel.appendLine(`Config changed!`);
+        vscode.window
+            .showInformationMessage(
+                "The configuration has changed!\nReload the window for the changes to take effect.",
+                "Reload Now"
+            )
+            // eslint-disable-next-line no-unused-vars
+            .then((_) =>
+                vscode.commands.executeCommand("workbench.action.reloadWindow")
+            );
+    }
 }

--- a/src/paneREPL.ts
+++ b/src/paneREPL.ts
@@ -211,7 +211,7 @@ export async function createREPL(
         location: { viewColumn: vscode.ViewColumn.Beside, preserveFocus: true },
     });
     terminal.sendText(`${c.getCfgREPLPath(config)}`);
-    await help.sleep(c.replSleepTime);
+    await help.sleep(c.getCfgREPLDelay(config));
     terminal.sendText(`${c.getCfgREPLPromptFunction(config)}`);
     return terminal;
 }


### PR DESCRIPTION
* Make the delay between starting the terminal for the interactive REPL and sending data to the REPL configurable. See #5
* Add a popup window asking the user to confirm reloading the extension if the extension's configuration has been changed.

