### PR TITLE
Add command to remove evaluated values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Version 0.7.0 (2024-07-10)
 
+New command `Chez Scheme REPL: Remove all evaluated values from the view.`, `chezScheme.removeEvalVals` to remove all evaluated values from the current view.
+
 ### Bugfixes
 
 Special thanks to [migraine-user](https://github.com/migraine-user) for helping to fix these, it would not have been possible to fix them by myself.

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@
 ![Video of Autocompletion](./images/autocompletion.gif)
 - Interactive REPL pane to the side of the editor, with commands to send code to the REPL (see [Commands](#commands)).
 ![Video of Sending a S-Exp to the Interactive REPL](images/left_repl.gif)
-- Inline evaluation of expressions (see [Commands](#commands)).
+- Inline evaluation of expressions and the possibility to delete them(see [Commands](#commands)).
 ![Video of Inline Evaluation](images/eval_left.gif)
 - Macro expansion (see [Commands](#commands)).
 ![Video of Macro Expansion](images/macro-expand.gif)
@@ -94,6 +94,7 @@ Either
 - `Chez Scheme REPL: Send the whole current file to the REPL` (`chezScheme.sendFileToREPL`) - send the contents of the currently active source file to the REPL. Opens a new REPL window if no REPL is running.
 - `Chez Scheme REPL: Eval the selected s-expression.` (`chezScheme.evalSelection`) - evaluate the selected s-expression and print the value inline after the selected s-expression.
 - `Chez Scheme REPL: Eval s-expression left of the cursor.` (`chezScheme.evalLastSexp`) - evaluate the s-expression to the left of the cursor and print the value inline after this s-expression.
+- `Chez Scheme REPL: Remove all evaluated values from the view.` (`chezScheme.removeEvalVals`) - remove all evaluated values from the current view.
 - `Chez Scheme REPL: Expand all macros in the selected s-expression.` (`chezScheme.expandSelection`) - expand all macros in the selected s-expression in the REPL. Opens a new REPL window if no REPL is running.
 - `Chez Scheme REPL: Expand all macros in the s-expression left of the cursor.` (`chezScheme.expandLastSexp`) - expand all macros in the s-expression to the left of the cursor in the REPL. Opens a new REPL window if no REPL is running.
 - `Chez Scheme REPL: Check the current file for errors.` (`chezScheme.checkFile`) - check the current file by loading it into the REPL. Errors are shown in the `Problems` tab. Called on save of a Chez Scheme file.

--- a/package.json
+++ b/package.json
@@ -123,6 +123,10 @@
                 "title": "Chez Scheme REPL: Eval s-expression left of the cursor."
             },
             {
+                "command": "chezScheme.removeEvalVals",
+                "title": "Chez Scheme REPL: Remove all evaluated values from the view."
+            },
+            {
                 "command": "chezScheme.expandLastSexp",
                 "title": "Chez Scheme REPL: Expand all macros in the s-expression left of the cursor."
             },
@@ -194,6 +198,11 @@
                 {
                     "when": "resourceLangId == scheme",
                     "command": "chezScheme.evalLastSexp",
+                    "group": "z_commands"
+                },
+                {
+                    "when": "resourceLangId == scheme",
+                    "command": "chezScheme.removeEvalVals",
                     "group": "z_commands"
                 },
                 {

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -159,6 +159,11 @@ export const sendLastToREPL = "sendLastSexp";
 export const evalLast = "evalLastSexp";
 
 /**
+ * Remove all evaluation values from the current view.
+ */
+export const removeEvalVals = "removeEvalVals";
+
+/**
  * Expand all macros in the sexp left of the cursor.
  */
 export const expandLast = "expandLastSexp";

--- a/src/evalREPL.ts
+++ b/src/evalREPL.ts
@@ -346,6 +346,11 @@ async function evalSexp(
     }
 }
 
+/**
+ * Remove all evaluated values from the current view.
+ * @param env The extension environment.
+ * @param editor The current active editor.
+ */
 export async function removeEvalVals(
     env: h.Env,
     editor: vscode.TextEditor

--- a/src/evalREPL.ts
+++ b/src/evalREPL.ts
@@ -346,6 +346,35 @@ async function evalSexp(
     }
 }
 
+export async function removeEvalVals(
+    env: h.Env,
+    editor: vscode.TextEditor
+): Promise<void> {
+    const allRange = new vscode.Range(
+        editor.document.positionAt(0),
+        editor.document.positionAt(editor.document.getText().length)
+    );
+    decor.removeRange({
+        decorations: env.evalDecorations,
+        decoration: env.evalDecoration,
+        editor,
+        range: allRange,
+    });
+    decor.removeRange({
+        decorations: env.evalErrorDecorations,
+        decoration: env.evalErrorDecoration,
+        editor,
+        range: allRange,
+    });
+    env.outChannel.appendLine(
+        `Remove eval decorations from ${editor.document.fileName}`
+    );
+    env.evalDecorations.delete(editor.document);
+    env.evalErrorDecorations.delete(editor.document);
+    editor.setDecorations(env.evalDecoration, []);
+    editor.setDecorations(env.evalErrorDecoration, []);
+}
+
 /**
  * Return a `RegExp` to parse the output of a REPL evaluation or completion.
  * @param group The regexp string to match the actual result.

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -279,6 +279,8 @@ function registerCommands(env: h.Env): void {
 
     registerTextEditorCommand(env, c.checkFile, eR.loadFile);
 
+    registerTextEditorCommand(env, c.removeEvalVals, eR.removeEvalVals);
+
     env.outChannel.appendLine(`Registered all commands`);
 }
 


### PR DESCRIPTION
New command `Chez Scheme REPL: Remove all evaluated values from the view.`, `chezScheme.removeEvalVals` to remove all evaluated values from the current view.