### PR TITLE
Remove eval results on edits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ Add syntax highlighting for the new functions and parameters  of Chez 10.0 to th
 
 Special thanks to [migraine-user](https://github.com/migraine-user) for helping to fix these, it would not have been possible to fix them by myself.
 
+- Do not show more than one evaluated value for the same line: [#23](https://github.com/Release-Candidate/vscode-scheme-repl/issues/23)
+- Remove all evaluation results from the view if the text has been changed:[#23](https://github.com/Release-Candidate/vscode-scheme-repl/issues/23)
 - Check if the configured Scheme executable is working: [#20](https://github.com/Release-Candidate/vscode-scheme-repl/issues/20). If not, display an error popup.
 - Save the current Scheme file before evaluating if it doesn't exist yet: [#20](https://github.com/Release-Candidate/vscode-scheme-repl/issues/20).
 

--- a/src/evalREPL.ts
+++ b/src/evalREPL.ts
@@ -307,7 +307,7 @@ async function evalSexp(
         data.exp.sexp
     );
     env.outChannel.appendLine(
-        `Sent ${data.exp.sexp} to REPL using command ${c.cfgSection}.${data.vscodeCommand}`
+        `Sent ${data.exp.sexp} to REPL using command ${c.cfgSection}.${data.vscodeCommand} Range ${data.range.start.line} - ${data.range.end.line}`
     );
     if (out.error || out.stderr) {
         const errMsg =

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -64,7 +64,7 @@ export async function activate(context: vscode.ExtensionContext) {
  * Setup the extension.
  * @param env The extension's environment.
  */
-// eslint-disable-next-line max-statements
+// eslint-disable-next-line max-statements, max-lines-per-function
 async function setupExtension(env: h.Env) {
     const editorChangedSubscription = vscode.window.onDidChangeActiveTextEditor(
         (editor) => {
@@ -72,6 +72,11 @@ async function setupExtension(env: h.Env) {
         }
     );
     env.context.subscriptions.push(editorChangedSubscription);
+
+    const textChangedSubscription = vscode.workspace.onDidChangeTextDocument(
+        (e) => textChanged(env, e)
+    );
+    env.context.subscriptions.push(textChangedSubscription);
 
     subscribeOnSave(env);
 
@@ -111,6 +116,19 @@ async function setupExtension(env: h.Env) {
                 root?.name
             }.\nChange chezScheme.schemePath in the 'Chez Scheme' configuration.\nSee the 'Output' window view of 'Chez Scheme REPL' for details.`
         );
+    }
+}
+
+/**
+ * Called, if any text document has changed.
+ * If the current active editor has been changed, remove the eval decorations.
+ * @param env The extension's environment.
+ * @param ev The change event.
+ */
+function textChanged(env: h.Env, ev: vscode.TextDocumentChangeEvent): void {
+    const maybeEditor = vscode.window.activeTextEditor;
+    if (maybeEditor && maybeEditor.document === ev.document) {
+        eR.removeEvalVals(env, maybeEditor);
     }
 }
 

--- a/src/textDecorations.ts
+++ b/src/textDecorations.ts
@@ -266,9 +266,7 @@ function addOrReplaceDecoration(
     options: vscode.DecorationOptions
 ) {
     const sameRange = decoration.findIndex(
-        (d) =>
-            d.range.start.line === options.range.start.line &&
-            d.range.end.line === options.range.end.line
+        (d) => d.range.start.line === options.range.start.line
     );
     if (sameRange > -1) {
         decoration[sameRange] = options;
@@ -291,9 +289,7 @@ export function removeRange(data: {
     const maybeRemove = data.decorations.get(data.editor.document);
     if (maybeRemove) {
         const removeIDX = maybeRemove.findIndex(
-            (d) =>
-                d.range.start.line === data.range.start.line &&
-                d.range.end.line === data.range.end.line
+            (d) => d.range.start.line === data.range.start.line
         );
         if (removeIDX > -1) {
             maybeRemove.splice(removeIDX, 1);


### PR DESCRIPTION
- Do not show more than one evaluated value for the same line
- Remove all evaluation results from the view if the text has been changed