### PR TITLE
Warning popup on unsaved changes when evaluating inline and fix parsing of escaped quotes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Chez Scheme REPL for Visual Studio Code Changelog
 
+## Version 0.7.1 (2024-07-13)
+
+Special thanks to [migraine-user](https://github.com/migraine-user) for helping with these:
+
+Add a popup warning if the file has unsaved changes before inline evaluating some expression.
+
+### Bugfixes
+
+- Fix the S-expression parser's handling of escaped quotes in strings
+
 ## Version 0.7.0 (2024-07-12)
 
 New command `Chez Scheme REPL: Remove all evaluated values from the view.`, `chezScheme.removeEvalVals` to remove all evaluated values from the current view.

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "vscode-scheme-repl",
     "displayName": "Chez Scheme REPL",
-    "version": "0.7.0",
+    "version": "0.7.1",
     "preview": false,
     "publisher": "release-candidate",
     "description": "Support for Chez Scheme: Highlighting, autocompletion, documentation on hover and syntax checks.",

--- a/src/evalREPL.ts
+++ b/src/evalREPL.ts
@@ -410,6 +410,16 @@ async function runREPLCommand(
     if (document.isUntitled) {
         await document.save();
     }
+    if (document.isDirty) {
+        const response = await vscode.window.showWarningMessage(
+            "The file has unsaved changes, these will not be send to the REPL.",
+            "Save changes and eval",
+            "Eval without saving"
+        );
+        if (response === "Save changes and eval") {
+            await document.save();
+        }
+    }
     return h.runCommand({
         root: root ? root.uri.fsPath : "./",
         args: [c.replQuietArg],

--- a/src/sexps.ts
+++ b/src/sexps.ts
@@ -377,6 +377,27 @@ function endOfSexp(data: {
             delimString: "{",
         });
     } else if (data.s.endsWith('"') && data.delim === "Quote") {
+        // cHECK IF ESCAPED
+        let toCheck = data.s.slice(0, -1);
+        let numBackSlash = 0;
+        let backSlashes = "";
+        while (toCheck.endsWith("\\")) {
+            toCheck = toCheck.slice(0, -1);
+            numBackSlash += 1;
+            backSlashes += "\\";
+        }
+        // eslint-disable-next-line no-magic-numbers
+        if (numBackSlash % 2 === 1) {
+            return (
+                parseSexpToLeft(
+                    data.delimStack,
+                    data.s.slice(0, -1 - numBackSlash),
+                    data.level
+                ) +
+                backSlashes +
+                '"'
+            );
+        }
         data.delimStack.pop();
         const newLevel = data.level - 1;
         if (newLevel === 0) {
@@ -385,9 +406,11 @@ function endOfSexp(data: {
             return (
                 parseSexpToLeft(
                     data.delimStack,
-                    data.s.slice(0, -1),
+                    data.s.slice(0, -1 - numBackSlash),
                     newLevel
-                ) + '"'
+                ) +
+                backSlashes +
+                '"'
             );
         }
     }

--- a/src/sexps.ts
+++ b/src/sexps.ts
@@ -377,7 +377,6 @@ function endOfSexp(data: {
             delimString: "{",
         });
     } else if (data.s.endsWith('"') && data.delim === "Quote") {
-        // cHECK IF ESCAPED
         let toCheck = data.s.slice(0, -1);
         let numBackSlash = 0;
         let backSlashes = "";

--- a/test/sexps-test.ts
+++ b/test/sexps-test.ts
@@ -238,6 +238,22 @@ mocha.describe("Sexp parsing functions", () => {
                 "Vector 'sdfgdgf #125vfx(255 0 255)' -> '#125vfx(255 0 255)' "
             );
         });
+        mocha.it(
+            'Escaped Quotes `not this \'[1 ("asd" ) "as\\"d"  asdasd () ]`',
+            () => {
+                chai.assert.deepEqual(
+                    s.getSexpToLeft(
+                        'not this \'[1 ("asd" ) "as\\"d"  asdasd () ]'
+                    ),
+                    {
+                        sexp: '\'[1 ("asd" ) "as\\"d"  asdasd () ]',
+                        startCol: 9,
+                        startLine: 0,
+                    },
+                    'Vector `not this \'[1 ("asd" ) "as\\"d"  asdasd () ]` ->  `\'[1 ("asd" ) "as\\"d"  asdasd () ]`'
+                );
+            }
+        );
         mocha.it("Gensym 'sdfgdgf #{g0 gdfgez754123245}'", () => {
             chai.assert.deepEqual(
                 s.getSexpToLeft("sdfgdgf #{g0 gdfgez754123245}"),


### PR DESCRIPTION
- Fix the S-expression parser's handling of escaped quotes in strings
- Add a popup warning if the file has unsaved changes before inline evaluating some expression.
