### PR TITLE
Don't check for unsaved changes on autocomplete, only when explicitly…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Chez Scheme REPL for Visual Studio Code Changelog
 
+## Version 0.7.2 (2024-07-15)
+
+Special thanks to [migraine-user](https://github.com/migraine-user) for helping with these:
+
+### Bugfixes
+
+- Do not check for unsaved changes for auto-completions, only when explicitly evaluating expressions.
+
 ## Version 0.7.1 (2024-07-13)
 
 Special thanks to [migraine-user](https://github.com/migraine-user) for helping with these:

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "vscode-scheme-repl",
     "displayName": "Chez Scheme REPL",
-    "version": "0.7.1",
+    "version": "0.7.2",
     "preview": false,
     "publisher": "release-candidate",
     "description": "Support for Chez Scheme: Highlighting, autocompletion, documentation on hover and syntax checks.",


### PR DESCRIPTION
Do not check for unsaved changes for auto-completions, only when explicitly evaluating expressions. No popup, if the evaluation has been triggered by an auto-completion